### PR TITLE
Make SSL protocols configurable with secure defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Terraform version 0.11.7 or newer is required for this module to work.
 | default_ttl | The default amount of time an object is ina CloudFront cache before it sends another request in absence of Cache-Control | string | 300 | no |
 | max_ttl | The maxium amount of seconds you want CloudFront to cache the object, before feching it from the origin | string | 31536000 | no |
 | enabled | Whether the distribution is enabled or not | string | `true` | no |
+| origin_ssl_protocols | The SSL/TLS protocols to use when talking to the origin | list | `["TLSv1.2", "TLSv1.1"]` | no |
+| minimum_protocol_version | The minimum version of the SSL protocol that you want CloudFront to use for HTTPS connections. | string | TLSv1.1_2016 | no |
 
 
 
@@ -64,4 +66,3 @@ Maintained by [Soroush Atarod](https://github.com/soroushatarod). Find out more,
 ## License
 
 Apache 2 Licensed. See LICENSE for full details.
-

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ resource "aws_cloudfront_distribution" "cdn" {
       http_port              = "${var.http_port}"
       https_port             = "${var.https_port}"
       origin_protocol_policy = "${var.origin_protocol_policy}"
-      origin_ssl_protocols   = ["SSLv3", "TLSv1"]
+      origin_ssl_protocols   = ["${var.origin_ssl_protocols}"]
     }
   }
 
@@ -29,7 +29,7 @@ resource "aws_cloudfront_distribution" "cdn" {
     cloudfront_default_certificate = false
     acm_certificate_arn            = "${var.acm_certificate_arn}"
     ssl_support_method             = "sni-only"
-    minimum_protocol_version       = "TLSv1.1_2016"
+    minimum_protocol_version       = "${var.minimum_protocol_version}"
   }
 
   default_cache_behavior {

--- a/variables.tf
+++ b/variables.tf
@@ -68,5 +68,17 @@ variable "max_ttl" {
   default     = 31536000
 }
 
+variable "origin_ssl_protocols" {
+  description = "The SSL/TLS protocols that you want CloudFront to use when communicating with your origin over HTTPS. A list of one or more  of SSLv3, TLSv1, TLSv1.1, and TLSv1.2."
+  default     = ["TLSv1.2", "TLSv1.1"]
+  type        = "list"
+}
+
+variable "minimum_protocol_version" {
+  description = "The minimum version of the SSL protocol that you want CloudFront to use for HTTPS connections."
+  default     = "TLSv1.1_2016"
+  type        = "string"
+}
+
 # variable "acm_certificate_arn" {}
 


### PR DESCRIPTION
SSLv3 shouldn't be in the default list, becuase it really shouldn't be used much at all. https://disablessl3.com/. Sometimes less that ideal defaults are needed, so I'm also exposing the flag as a variable.