### PR TITLE
Allignin this module with AWS Whitepaper for "Best Practices for WordPress on AWS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Help Contribute to Open Source](https://www.codetriage.com/soroushatarod/terraform-cloudfront-wordpress/badges/users.svg)](https://www.codetriage.com/soroushatarod/terraform-cloudfront-wordpress)
 
-Terraform module which creates the CloudFront distribution for a WordPress website with pre-configured settings.
+Terraform module, which creates the CloudFront distribution for a WordPress website with pre-configured settings based on the official AWS Whitepaper: https://docs.aws.amazon.com/whitepapers/latest/best-practices-wordpress/cloudfront-distribution-creation.html  
 
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ module "cloudfront_wordpress" {
    domain_name = "example.com"
    origin_id = "E22XRTe7wQ72"
    enabled = true
-   origin_protocol_policy = "http-only"
    acm_certificate_arn = "arn:aws:acm:us-east-1:20:certificate/9489-60"
    tags = {
      name = "production"
@@ -40,7 +39,7 @@ Terraform version 0.11.7 or newer is required for this module to work.
 | domain_name | The website root domain name | string | `false` | yes |
 | origin_id | Unique identifer for the origin example: master_origin | string | `false` | yes |
 | acm_certificate_arn | The SSL certificate ARN (Amazon Resource Name). This can be found on the “Certificate Manager” dashboard. | string | `false` | yes |
-| origin_protocol_policy | Either one of them (http-only, https-only,match-viewer) | string | `false` | yes
+| origin_protocol_policy | Either one of them (http-only, https-only,match-viewer) | string | `match-viewer` | yes
 | tags | Tags to assign to the distribution | string | `<map>` | yes |
 | cookies_whitelisted_names | List of cookies to be whitelisted. By default has the WordPress cookies | string | `<list>` | no |
 | http_port | The HTTP port which Cloudfront should connect to the origin | string | 80 | no |

--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ resource "aws_cloudfront_distribution" "cdn" {
     }
 
     compress               = true
-    viewer_protocol_policy = "allow-all"
+    viewer_protocol_policy = "${var.default_viewer_protocol_policy}"
     min_ttl                = "${var.min_ttl}"
     default_ttl            = "${var.default_ttl}"
     max_ttl                = "${var.max_ttl}"

--- a/main.tf
+++ b/main.tf
@@ -95,4 +95,25 @@ resource "aws_cloudfront_distribution" "cdn" {
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
   }
+
+  ordered_cache_behavior {
+    path_pattern     = "wp-content/*"
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "${var.origin_id}"
+
+    forwarded_values {
+      query_string = true
+      headers      = ["Host", "Origin"]
+
+      cookies {
+        forward           = "whitelist"
+        whitelisted_names = "${var.cookies_whitelisted_names}"
+      }
+    }
+
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
 }

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "aws_cloudfront_distribution" "cdn" {
 
     forwarded_values {
       query_string = true
-      headers      = ["Host", "Origin"]
+      headers      = ["Host", "Origin", "CloudFront-Forwarded-Proto", "CloudFront-Is-Mobile-Viewer", "CloudFront-Is-Tablet-Viewer", "CloudFront-Is-Desktop-Viewer"]
 
       cookies {
         forward           = "whitelist"
@@ -50,7 +50,7 @@ resource "aws_cloudfront_distribution" "cdn" {
     }
 
     compress               = true
-    viewer_protocol_policy = "redirect-to-https"
+    viewer_protocol_policy = "allow-all"
     min_ttl                = "${var.min_ttl}"
     default_ttl            = "${var.default_ttl}"
     max_ttl                = "${var.max_ttl}"
@@ -64,11 +64,10 @@ resource "aws_cloudfront_distribution" "cdn" {
 
     forwarded_values {
       query_string = true
-      headers      = ["Host", "Origin"]
+      headers      = ["*"]
 
       cookies {
-        forward           = "whitelist"
-        whitelisted_names = "${var.cookies_whitelisted_names}"
+        forward           = "all"
       }
     }
 
@@ -84,11 +83,10 @@ resource "aws_cloudfront_distribution" "cdn" {
 
     forwarded_values {
       query_string = true
-      headers      = ["Host", "Origin"]
+      headers      = ["*"]
 
       cookies {
-        forward           = "whitelist"
-        whitelisted_names = "${var.cookies_whitelisted_names}"
+        forward           = "all"
       }
     }
 
@@ -104,16 +102,32 @@ resource "aws_cloudfront_distribution" "cdn" {
 
     forwarded_values {
       query_string = true
-      headers      = ["Host", "Origin"]
 
       cookies {
-        forward           = "whitelist"
-        whitelisted_names = "${var.cookies_whitelisted_names}"
+        forward           = "none"
       }
     }
 
     compress               = true
-    viewer_protocol_policy = "redirect-to-https"
+    viewer_protocol_policy = "allow-all"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "wp-includes/*"
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "${var.origin_id}"
+
+    forwarded_values {
+      query_string = true
+
+      cookies {
+        forward           = "none"
+      }
+    }
+
+    compress               = true
+    viewer_protocol_policy = "allow-all"
   }
 
 }

--- a/variables.tf
+++ b/variables.tf
@@ -55,7 +55,7 @@ variable "origin_protocol_policy" {
 
 variable "min_ttl" {
   description = "The minimum time you want objects to stay in CloudFront"
-  default     = 0
+  default     = 1
 }
 
 variable "default_ttl" {

--- a/variables.tf
+++ b/variables.tf
@@ -64,7 +64,7 @@ variable "default_ttl" {
 }
 
 variable "max_ttl" {
-  description = "The maxium amount of seconds you want CloudFront to cache the object, before feching it from the origin"
+  description = "The maximum amount of seconds you want CloudFront to cache the object, before fetching it from the origin"
   default     = 31536000
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -59,7 +59,7 @@ variable "min_ttl" {
 }
 
 variable "default_ttl" {
-  description = "The default amount of time an object is ina CloudFront cache before it sends another request in absence of Cache-Control"
+  description = "The default amount of time an object is in a CloudFront cache before it sends another request in absence of Cache-Control"
   default     = 300
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -60,7 +60,7 @@ variable "min_ttl" {
 
 variable "default_ttl" {
   description = "The default amount of time an object is in a CloudFront cache before it sends another request in absence of Cache-Control"
-  default     = 300
+  default     = 86400
 }
 
 variable "max_ttl" {

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,11 @@ variable "origin_protocol_policy" {
   default     = "match-viewer"
 }
 
+variable "default_viewer_protocol_policy" {
+  description = "Either one of them (https-only, redirect-to-https, allow-all)"
+  default     = "allow-all"
+}
+
 variable "min_ttl" {
   description = "The minimum time you want objects to stay in CloudFront"
   default     = 1

--- a/variables.tf
+++ b/variables.tf
@@ -50,7 +50,8 @@ variable "https_port" {
 }
 
 variable "origin_protocol_policy" {
-  description = "Either one of them (http-only, https-only,match-viewer) "
+  description = "Either one of them (http-only, https-only, match-viewer)"
+  default     = "match-viewer"
 }
 
 variable "min_ttl" {


### PR DESCRIPTION
Hi
I wanted to write my module, but I saw this one. There are some misconfigurations in terms of some default values. I decided to change it and do this like it is in AWS Whitepaper "Best Practices for WordPress on AWS". https://docs.aws.amazon.com/whitepapers/latest/best-practices-wordpress/cloudfront-distribution-creation.html

Please check the changes and approve them if it is okay for you. If something is wrong or it is better to do it another way, please let's discuss it here. 